### PR TITLE
refactor: AIプロンプトを簡潔化してLLM応答を短縮

### DIFF
--- a/src/ai/built-in-ai.ts
+++ b/src/ai/built-in-ai.ts
@@ -22,10 +22,7 @@ declare global {
   }
 }
 
-const SYSTEM_PROMPT = `あなたはことわざに詳しい文鳥です。
-ユーザーが言ったことわざについて、意味と由来を説明してください。
-知らないことわざでも知ったかぶりで創作して説明してください。
-フランクな口調で、日本語で、100文字程度で答えてください。`;
+const SYSTEM_PROMPT = `あなたは知ったかぶりの文鳥。ことわざの意味を2〜3文で短く答える。知らないことわざは創作する。フランクな口調。箇条書きや見出しは使わない。`;
 
 export class BuiltInAIProvider implements AIProvider {
   async isAvailable(): Promise<boolean> {
@@ -44,9 +41,11 @@ export class BuiltInAIProvider implements AIProvider {
     }
     const session = await window.LanguageModel.create({
       systemPrompt: SYSTEM_PROMPT,
+      temperature: 0.6,
+      topK: 3,
     });
     try {
-      const result = await session.prompt(`「${word}」ということわざについて教えて。`);
+      const result = await session.prompt(`「${word}」ってどういう意味？`);
       return result;
     } finally {
       session.destroy();


### PR DESCRIPTION
## Summary
- システムプロンプトを体言止めの簡潔な指示に書き換え、「2〜3文で短く答える」「箇条書きや見出しは使わない」を明示
- ユーザープロンプトを「教えて」→「どういう意味？」に変更し、回答スコープを限定
- `temperature: 0.6`, `topK: 3` を設定して冗長な出力を抑制

## Test plan
- [ ] `npm run dev` で開発サーバーを起動し、Chrome（Built-in AI対応版）でアクセス
- [ ] 既存のことわざ（例:「猿も木から落ちる」）で応答が2〜3文に収まることを確認
- [ ] 存在しないことわざ（ランダム生成）で知ったかぶり創作が機能することを確認
- [ ] Markdown書式（見出し・箇条書き・太字）が使われていないことを確認
- [ ] 応答時間が体感的に短縮されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)