### PR TITLE
chore: mainブランチでのファイル編集を防止するhookを追加

### DIFF
--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+# ファイルパスが空なら許可
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# ファイルのディレクトリでブランチを確認
+FILE_DIR=$(dirname "$FILE_PATH")
+BRANCH=$(git -C "$FILE_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null)
+
+# gitリポジトリ外なら許可
+if [ -z "$BRANCH" ]; then
+  exit 0
+fi
+
+# main以外なら許可
+if [ "$BRANCH" != "main" ]; then
+  exit 0
+fi
+
+# .claude/ やCLAUDE.md等の設定ファイルは許可
+REPO_ROOT=$(git -C "$FILE_DIR" rev-parse --show-toplevel 2>/dev/null)
+case "$FILE_PATH" in
+  "$REPO_ROOT/.claude/"*|"$REPO_ROOT/CLAUDE.md") exit 0 ;;
+esac
+
+# mainブランチでのソースコード編集をブロック
+echo "mainブランチ上でのファイル編集は禁止です。worktree + featureブランチを作成してください。" >&2
+exit 2

--- a/.claude/rules/branch-and-commit.md
+++ b/.claude/rules/branch-and-commit.md
@@ -1,5 +1,5 @@
 ---
-description: ブランチ戦略と Conventional Commits 規約
+description: コード変更前に必ず確認 — feature ブランチ + worktree で作業すること（main 直接編集禁止）
 ---
 
 ## ブランチ戦略（GitHub Flow）

--- a/.claude/rules/worktree-lifecycle.md
+++ b/.claude/rules/worktree-lifecycle.md
@@ -1,5 +1,5 @@
 ---
-description: Worktree の作成・管理・削除ルール
+description: 新しい作業は .worktrees/ に worktree を作成してから開始すること
 ---
 
 ## Worktree のライフサイクル

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,6 +20,15 @@
             "command": ".claude/hooks/pre-commit-check.sh"
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/branch-guard.sh"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary
- `PreToolUse` hookでEdit/Write実行前にmainブランチ上かチェックし、ソースファイル編集をブロック（`.claude/`やCLAUDE.mdは除外）
- rulesファイルのdescriptionを命令的な表現に変更し、Claudeが行動前にルールを意識しやすくした

## Test plan
- [ ] mainブランチ上で `src/` 配下のファイルを編集しようとするとブロックされることを確認
- [ ] mainブランチ上で `.claude/settings.json` や `CLAUDE.md` の編集は許可されることを確認
- [ ] worktree内でのファイル編集は通常通り許可されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)